### PR TITLE
Add deep_copy calls missing because of a Y2R bug

### DIFF
--- a/src/include/tftp-server/dialogs.rb
+++ b/src/include/tftp-server/dialogs.rb
@@ -198,7 +198,9 @@ module Yast
             if !Mode.config &&
                 Ops.less_than(SCR.Read(path(".target.size"), directory), 0)
               # the dir does not exist
-              ret = Popup.YesNo(Message.DirectoryDoesNotExistCreate(directory)) ? ret : nil
+              ret = Popup.YesNo(Message.DirectoryDoesNotExistCreate(directory)) ?
+                deep_copy(ret) :
+                nil
             end
           else
             UI.SetFocus(Id(:directory))


### PR DESCRIPTION
See https://github.com/yast/y2r/issues/47.
