### PR TITLE
[RFC] [Help needed] Force socket to start if the service will be active

### DIFF
--- a/src/modules/TftpServer.rb
+++ b/src/modules/TftpServer.rb
@@ -199,6 +199,7 @@ module Yast
         # so we must kill it otherwise it will be using the old parameters
         Yast2::Systemd::Service.find!("tftp").stop
       else
+        socket.start if service.active?
         service.save
       end
 


### PR DESCRIPTION

## Problem

The `tftp` service is not being started properly using the `yast-tftp-server` module, 

> Since the tftp service needs it socket running to start gracefully.

- https://bugzilla.suse.com/show_bug.cgi?id=1129246

## Solution

 * To start the socket first, or
 * To force the service `start_mode` to `:on_demand` if the service will be activated.

None of those approaches works properly for the `Reset` action.

More details in a (self)code review.

